### PR TITLE
Adds more file types to the auto exclude

### DIFF
--- a/src/lints/all-files-tested.ts
+++ b/src/lints/all-files-tested.ts
@@ -3,6 +3,7 @@ import { LintError, LintErrorType, Context, File, RuleConfig } from '../types'
 const EXCLUDE_EXTENSION = [
   'php',
   'yml',
+  'xml',
   'yaml',
   'md',
   'json',
@@ -12,6 +13,13 @@ const EXCLUDE_EXTENSION = [
   'npmrc',
   'scss',
   'css',
+  'nvmrc',
+  'tool-versions',
+  'editorconfig',
+  'threepio',
+  'dockerfile',
+  'prettierrc',
+  'prettierignore',
 ]
 
 const EXCLUDE_SUB_EXTENSIONS = ['d', 'config']


### PR DESCRIPTION
This should exclude more types of files from the check as they are not testable it doesn't make sense to test them.

Test Plan:
- tests pass

JIRA: [Fake-1]