### PR TITLE
feat: add ability to provide ignore globs for change size lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
+        "glob-to-regexp": "^0.4.1",
         "yaml": "^2.7.0"
       },
       "devDependencies": {
@@ -75,6 +76,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -1252,6 +1254,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
       "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.38.0",
         "@typescript-eslint/types": "5.38.0",
@@ -1515,6 +1518,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1890,6 +1894,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -1935,7 +1940,6 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.1.0.tgz",
       "integrity": "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "semver": "^7.0.0"
       }
@@ -2533,6 +2537,7 @@
       "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.2",
         "@humanwhocodes/config-array": "^0.10.4",
@@ -2673,7 +2678,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
       "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "eslint-utils": "^2.0.0",
         "regexpp": "^3.0.0"
@@ -2693,7 +2697,6 @@
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
       "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -2709,7 +2712,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -2719,6 +2721,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
       "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.4",
         "array.prototype.flat": "^1.2.5",
@@ -2892,6 +2895,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.1.tgz",
       "integrity": "sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -3455,6 +3459,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
       "version": "13.24.0",
@@ -4121,6 +4131,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5285,6 +5296,7 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6121,6 +6133,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "*.{js,ts}": "npm run lint"
   },
   "dependencies": {
+    "glob-to-regexp": "^0.4.1",
     "yaml": "^2.7.0"
   }
 }

--- a/src/lints/change-size.test.ts
+++ b/src/lints/change-size.test.ts
@@ -29,7 +29,7 @@ describe('#changeSize', () => {
       }),
     })
 
-    const { type, message } = await changeSize(fakeContext, 'warning')
+    const { type, message } = await changeSize(fakeContext, 'warning', {})
 
     expect(type).toBe('warning')
     expect(message)
@@ -56,9 +56,62 @@ describe('#changeSize', () => {
       }),
     })
 
-    const { type, message } = await changeSize(fakeContext, 'warning')
+    const { type, message } = await changeSize(fakeContext, 'warning', {})
 
     expect(type).toBe('none')
     expect(message).toBe(``)
+  })
+
+  test('ignores files matching provided ignore globs', async () => {
+    const fakeContext = generateStubContext({
+      files: ['src/main/foobar.txt', 'src/test/foobar.txt'].map((f) =>
+        generateFile({
+          filename: f,
+          additions: 250,
+          deletions: 250,
+          changes: 500,
+        }),
+      ),
+      pull_request: generateStubPullRequest({
+        additions: 500,
+        deletions: 500,
+        changed_files: 2,
+      }),
+    })
+
+    const { type, message } = await changeSize(fakeContext, 'warning', {
+      ignoredGlobs: ['src/test/*']
+    })
+
+    expect(type).toBe('none')
+    expect(message).toBe(``)
+  })
+
+  test('only ignores files matching provided ignore globs once if matching multiple globs', async () => {
+    const fakeContext = generateStubContext({
+      files: ['src/main/foobar.txt', 'src/test/foobar.txt'].map((f) =>
+        generateFile({
+          filename: f,
+          additions: 500,
+          deletions: 500,
+          changes: 1000,
+        }),
+      ),
+      pull_request: generateStubPullRequest({
+        additions: 1000,
+        deletions: 1000,
+        changed_files: 2,
+      }),
+    })
+
+    const { type, message } = await changeSize(fakeContext, 'warning', {
+      ignoredGlobs: ['src/test/*', 'src/test/*.txt']
+    })
+
+    expect(type).toBe('warning')
+    expect(message).toBe(`[There is a lot of change in this PR. Maybe reduce scope?](https://github.com/designfrontier/threepio/blob/main/docs/rules.md#change-size)
+-- 1000 added lines
+-- 1000 deleted lines
+-- 2 files changed`)
   })
 })

--- a/src/lints/change-size.ts
+++ b/src/lints/change-size.ts
@@ -1,4 +1,5 @@
-import { LintError, LintErrorType, Context, File } from '../types'
+import { LintError, LintErrorType, Context, File, RuleConfig } from '../types'
+const globToRegExp = require('glob-to-regexp')
 
 const LINE_CUTOFF = 500
 const FILE_CUTOFF = 10
@@ -6,6 +7,7 @@ const FILE_CUTOFF = 10
 export async function test(
   context: Context,
   level: LintErrorType,
+  config: RuleConfig
 ): Promise<LintError> {
   const { files, pull_request: pullRequest } = context
   const { additions, deletions, changed_files: changedFiles } = pullRequest
@@ -22,9 +24,33 @@ export async function test(
     { additions: 0, deletions: 0 },
   )
 
+  const ignoredChanges = files.reduce(
+    (a, f: File) => {
+      [...(config?.ignoredGlobs ?? [])].some(ignoredGlob => {
+        if (f.filename.match(globToRegExp(ignoredGlob))) {
+          a.additions += f.additions
+          a.deletions += f.deletions
+          return true
+        }
+      })
+      return a
+    },
+    { additions: 0, deletions: 0}
+  )
+
+  const irrelevantChanges = [packageChanges, ignoredChanges].reduce(
+    (a, changes: {additions: number, deletions: number}) => (
+      {
+        additions: changes.additions + a.additions,
+        deletions: changes.deletions + a.deletions
+      }
+    ),
+    { additions: 0, deletions: 0}
+  )
+
   // we exclude package-lock.json changes since they are generated
-  return additions - packageChanges.additions >= LINE_CUTOFF ||
-    deletions - packageChanges.deletions >= LINE_CUTOFF ||
+  return additions - irrelevantChanges.additions >= LINE_CUTOFF ||
+    deletions - irrelevantChanges.deletions >= LINE_CUTOFF ||
     changedFiles >= FILE_CUTOFF
     ? {
         type: level,


### PR DESCRIPTION
Certain languages can be quite verbose and lead to larger changes in certain areas. This change allows for a configuration option to allow certain files to be removed from consideration for the change size lint.